### PR TITLE
Add Rails generator for migration to create trigger

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,8 +10,8 @@ jobs:
           - PGUSER: postgres
       - image: circleci/postgres:9.6
         environment:
-          POSTGRES_USER: postgres
-          POSTGRES_DB: postgres_pub_sub_test
+          - POSTGRES_USER: postgres
+          - POSTGRES_DB: postgres_pub_sub_test
     steps:
       - checkout
 
@@ -27,6 +27,7 @@ jobs:
       - run: bundle check --path=vendor/bundle || bundle install --path=vendor/bundle --jobs=4 --retry=3
       - run: bundle clean --force
 
+      # Install Postgres client
       - run: sudo apt update && sudo apt install postgresql-client
 
       # Store bundle cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
 # activerecord-postgres_pub_sub
 
-## v0.1.0
+## v0.1.0 (unreleased)
 - Initial version

--- a/README.md
+++ b/README.md
@@ -63,6 +63,19 @@ ActiveRecord::PostgresPubSub::Listener.listen("notify_channel", listen_timeout: 
 end
 ```
 
+### Generator
+
+This gem contains a Rails generator for a migration to add a trigger to notify on insert to a table.
+
+The generator must be run with a model name corresponding to the table.
+
+```bash
+rails generate active_record:postgres_pub_sub:notify_on_insert --model_name NameSpace::Entity
+```
+
+In this example, notification events would be generated for the channel named `"name_space_entity"` based
+on inserts to the `name_space_entities` table.
+
 ## Development
 
 After checking out the repo, run `bin/setup` to install dependencies. Then,

--- a/lib/activerecord/postgres_pub_sub/version.rb
+++ b/lib/activerecord/postgres_pub_sub/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module PostgresPubSub
-    VERSION = "0.1.0".freeze
+    VERSION = "0.1.0.rc0".freeze
   end
 end

--- a/lib/generators/active_record/postgres_pub_sub/notify_on_insert_generator.rb
+++ b/lib/generators/active_record/postgres_pub_sub/notify_on_insert_generator.rb
@@ -1,0 +1,42 @@
+require "rails/generators"
+require "rails/generators/migration"
+require "rails/generators/active_record"
+
+module ActiveRecord
+  module PostgresPubSub
+    class NotifyOnInsertGenerator < Rails::Generators::Base
+      include ActiveRecord::Generators::Migration
+
+      source_root File.join(File.dirname(__FILE__), "templates")
+
+      class_option :model_name, type: :string
+
+      def create_migration_file
+        migration_template("create_notify_on_insert_trigger.rb.erb",
+                           "db/migrate/create_notify_on_#{table_name}_insert_trigger.rb")
+      end
+
+      private
+
+      def model_name
+        @model_name ||= options.fetch(:model_name)
+      end
+
+      def table_name
+        @table_name ||= model_name.tableize.tr("/", "_")
+      end
+
+      def notification_name
+        @notification_name || table_name.singularize
+      end
+
+      def table_module
+        @module_name ||= model_name.deconstantize.underscore.tr("/", "_")
+      end
+
+      def model_title
+        @model_title ||= table_name.camelize
+      end
+    end
+  end
+end

--- a/lib/generators/active_record/postgres_pub_sub/templates/create_notify_on_insert_trigger.rb.erb
+++ b/lib/generators/active_record/postgres_pub_sub/templates/create_notify_on_insert_trigger.rb.erb
@@ -1,0 +1,31 @@
+class CreateNotifyOn<%= model_title %>InsertTrigger < ActiveRecord::Migration[5.1]
+  TABLE_NAME = "<%= table_name %>".freeze
+  NOTIFICATION_NAME = "<%= notification_name %>".freeze
+  TABLE_MODULE = "<%= table_module %>".freeze
+
+  def up
+    execute <<-SQL
+      CREATE OR REPLACE FUNCTION notify_#{TABLE_MODULE}_listeners() RETURNS TRIGGER AS $$
+      DECLARE
+      BEGIN
+        PERFORM pg_notify('#{NOTIFICATION_NAME}', null);
+        RETURN NEW;
+      END;
+      $$ LANGUAGE plpgsql
+    SQL
+
+    execute <<-SQL
+      CREATE TRIGGER #{TABLE_MODULE}_trigger
+      AFTER INSERT
+      ON #{TABLE_NAME}
+      FOR EACH STATEMENT
+      EXECUTE PROCEDURE notify_#{TABLE_MODULE}_listeners()
+    SQL
+  end
+
+  def down
+    execute <<-SQL
+      DROP FUNCTION notify_#{TABLE_MODULE}_listeners() CASCADE
+    SQL
+  end
+end


### PR DESCRIPTION
## What did we change?

Added a generator for a migration that adds a trigger to call NOTIFY when a row is inserted to a table.

## Why are we doing this?

This is being done generically here because I'm planning to eventually use it in a couple of places. The first use will be in a transactional publisher for `ezcater_kafka`. There instead of producing directly to Kafka, we'll insert into a messages table first, then (using the trigger created here) listen for notifications in another process that will talk to Kafka.

I'm not expecting this generator to be invoked directly by a developer. In a change to be submitted soon, `ezcater_kafka` will invoke this programmatically from one of its generators.

This setup has been tested locally with delivery: creating a messages table, adding the trigger to it, running a listener, inserting into the table, and seeing that the listener receives the notification.

## How was it tested?
- [ ] Specs
- [x] Locally
- [ ] Staging
