### PR TITLE
Loosen ActiveRecord dependency to allow rails 5.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # activerecord-postgres_pub_sub
 
+## v0.2.0 (unreleased)
+- Loosen `activerecord` dependency to allow for v5.2.0
+
 ## v0.1.0
 - Initial version

--- a/activerecord-postgres_pub_sub.gemspec
+++ b/activerecord-postgres_pub_sub.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", "~> 5.1.4"
+  spec.add_runtime_dependency "activerecord", ">= 5.1.0", "<= 5.2.0"
   spec.add_runtime_dependency "pg", "~> 0.18"
   spec.add_runtime_dependency "private_attr"
   spec.add_runtime_dependency "with_advisory_lock"

--- a/lib/activerecord/postgres_pub_sub/version.rb
+++ b/lib/activerecord/postgres_pub_sub/version.rb
@@ -1,5 +1,5 @@
 module ActiveRecord
   module PostgresPubSub
-    VERSION = "0.1.0".freeze
+    VERSION = "0.2.0".freeze
   end
 end


### PR DESCRIPTION
## What did we change?
allow activerecord 5.2.x. i looked through the CHANGELOG and nothing stood out. we arent using a whole lot from activerecord anyway

## Why are we doing this?
so apps can upgrade to rails 5.2

## How was it tested?
- [ ] Specs
- [ ] Locally
- [ ] Staging
