### PR TITLE
Use rubygems in Gemfile and add Circle badge

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-source "https://ezcater.jfrog.io/ezcater/api/gems/ezcater-gem-source"
+source "https://rubygems.org"
 
 # override the :github shortcut to be secure by using HTTPS
 git_source(:github) { |repo_name| "https://github.com/#{repo_name}.git" }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # activerecord-postgres_pub_sub
 
+[![CircleCI](https://circleci.com/gh/ezcater/activerecord-postgres_pub_sub.svg?style=svg)](https://circleci.com/gh/ezcater/activerecord-postgres_pub_sub)
+
 This gem contains support for PostgreSQL LISTEN and NOTIFY functionality: 
 [doc](https://www.postgresql.org/docs/9.6/static/libpq-notify.html).
 


### PR DESCRIPTION
## What did we change?

Use rubygems as source in Gemfile and add CircleCI badge.

## Why are we doing this?

We want to open source this repo.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
