### PR TITLE
Update to use open sourced ezcater_matchers

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -4,7 +4,3 @@ inherit_gem:
 Naming/FileName:
   Exclude:
   - "lib/activerecord-postgres_pub_sub.rb"
-
-# TODO: renable after open-sourcing ezcater_matchers
-Ezcater/RspecMatchOrderedArray:
-  Enabled: false

--- a/activerecord-postgres_pub_sub.gemspec
+++ b/activerecord-postgres_pub_sub.gemspec
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-lib = File.expand_path("../lib", __FILE__)
+lib = File.expand_path("lib", __dir__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "activerecord/postgres_pub_sub/version"
 
@@ -48,7 +48,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "appraisal"
   spec.add_development_dependency "bundler", "~> 1.12"
   spec.add_development_dependency "database_cleaner"
-  spec.add_development_dependency "ezcater_rubocop", "0.52.8"
+  spec.add_development_dependency "ezcater_matchers"
+  spec.add_development_dependency "ezcater_rubocop", "0.57.2"
   spec.add_development_dependency "overcommit"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.4"

--- a/spec/active_record/postgres_pub_sub/listener_spec.rb
+++ b/spec/active_record/postgres_pub_sub/listener_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe ActiveRecord::PostgresPubSub::Listener, cleaner_strategy: :trunca
       end
 
       wait_for("notification received") { state.count > 0 }
-      expect(state.payloads).to eq([nil])
+      expect(state.payloads).to match_ordered_array([nil])
       expect(state.count).to eq(1)
     end
 
@@ -51,7 +51,7 @@ RSpec.describe ActiveRecord::PostgresPubSub::Listener, cleaner_strategy: :trunca
         end
 
         wait_for("notification received") { state.count == 3 }
-        expect(state.payloads).to eq(%w(0 1 2))
+        expect(state.payloads).to match_ordered_array(%w(0 1 2))
       end
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,11 +1,12 @@
 # frozen_string_literal: true
 
-$LOAD_PATH.unshift File.expand_path("../../lib", __FILE__)
+$LOAD_PATH.unshift File.expand_path("../lib", __dir__)
 require "simplecov"
 SimpleCov.start
 
 require "activerecord-postgres_pub_sub"
 require "database_cleaner"
+require "ezcater_matchers"
 
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|


### PR DESCRIPTION
## What did we change?

Use `ezcater_matchers` from rubygems and update to the latest rubocop.

## Why are we doing this?

Cleaning things up in order to open source and talk about these gems.

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
