### PR TITLE
 Compatibility with StrongMigrations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # activerecord-postgres_pub_sub
 
+## v0.4.0 (unreleased)
+- Add safe instance variable if StrongMigrations is used.
+
 ## v0.3.0
 - Add support for Rails 5.2.
 

--- a/lib/activerecord/postgres_pub_sub/version.rb
+++ b/lib/activerecord/postgres_pub_sub/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module PostgresPubSub
-    VERSION = "0.3.0"
+    VERSION = "0.4.0.rc0"
   end
 end

--- a/lib/activerecord/postgres_pub_sub/version.rb
+++ b/lib/activerecord/postgres_pub_sub/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module PostgresPubSub
-    VERSION = "0.4.0.rc0"
+    VERSION = "0.4.0.rc1"
   end
 end

--- a/lib/generators/active_record/postgres_pub_sub/notify_on_insert_generator.rb
+++ b/lib/generators/active_record/postgres_pub_sub/notify_on_insert_generator.rb
@@ -39,6 +39,10 @@ module ActiveRecord
       def model_title
         @model_title ||= table_name.camelize
       end
+
+      def strong_migrations
+        defined?(StrongMigrations)
+      end
     end
   end
 end

--- a/lib/generators/active_record/postgres_pub_sub/templates/create_notify_on_insert_trigger.rb.erb
+++ b/lib/generators/active_record/postgres_pub_sub/templates/create_notify_on_insert_trigger.rb.erb
@@ -4,7 +4,7 @@ class CreateNotifyOn<%= model_title %>InsertTrigger < ActiveRecord::Migration[5.
   TABLE_MODULE = "<%= table_module %>".freeze
 
   def up
-    <% if strong_migrations -%>@safe = true<% end -%>
+    <% if strong_migrations %>@safe = true<% end %>
     execute <<-SQL
       CREATE OR REPLACE FUNCTION notify_#{TABLE_MODULE}_listeners() RETURNS TRIGGER AS $$
       DECLARE
@@ -25,7 +25,7 @@ class CreateNotifyOn<%= model_title %>InsertTrigger < ActiveRecord::Migration[5.
   end
 
   def down
-    <% if strong_migrations -%>@safe = true<% end -%>
+    <% if strong_migrations %>@safe = true<% end %>
     execute <<-SQL
       DROP FUNCTION notify_#{TABLE_MODULE}_listeners() CASCADE
     SQL

--- a/lib/generators/active_record/postgres_pub_sub/templates/create_notify_on_insert_trigger.rb.erb
+++ b/lib/generators/active_record/postgres_pub_sub/templates/create_notify_on_insert_trigger.rb.erb
@@ -4,6 +4,7 @@ class CreateNotifyOn<%= model_title %>InsertTrigger < ActiveRecord::Migration[5.
   TABLE_MODULE = "<%= table_module %>".freeze
 
   def up
+    <% if strong_migrations -%>@safe = true<% end -%>
     execute <<-SQL
       CREATE OR REPLACE FUNCTION notify_#{TABLE_MODULE}_listeners() RETURNS TRIGGER AS $$
       DECLARE
@@ -24,6 +25,7 @@ class CreateNotifyOn<%= model_title %>InsertTrigger < ActiveRecord::Migration[5.
   end
 
   def down
+    <% if strong_migrations -%>@safe = true<% end -%>
     execute <<-SQL
       DROP FUNCTION notify_#{TABLE_MODULE}_listeners() CASCADE
     SQL


### PR DESCRIPTION
## What did we change?

Added a `@safe = true` is StrongMigrations is present.

## Why are we doing this?

To make the generated migration compatible with StrongMigrations.

Adding the instance variable seemed cleaner than trying to wrap everything in a `safety_assured` block or maintain two copies of the migration.

This is being done in preparation for adding ezcater_migrations to the rails-template.

## How was it tested?
- [x] Specs
- [x] Locally
- [ ] Staging
