### PR TITLE
support listen multi channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # activerecord-postgres_pub_sub
 
+## Unreleased
+- Add support listening multiple channels.
+
 ## v2.1.0
 - Set required ruby version to 2.7.0
 - Add support for Rails 7.0


### PR DESCRIPTION
## What did we change?
support listening multiple channels in one listener instance
``` ruby
ActiveRecord::PostgresPubSub::Listener.listen('rose', ' violets', notify_only: false) do |listener|
  listener.on_notify do |payload, channel|
      # channel return as notified channel name
      case channel
      when 'rose'
        puts 'red'
      when 'violets'
        puts 'blue' 
      end
  end
end
```
it's also compatible with current version:
``` ruby
ActiveRecord::PostgresPubSub::Listener.listen('vanilla', notify_only: false) do |listener|
  listener.on_notify do |payload|
    puts payload
  end
end
```
not testing yet but should working under `:notify_only`  mode

## Why are we doing this?
listening multiple channels and known which channel was notified. able to set different handler for each channel.
 
## How was it tested?
- [ ] Specs
- [x] Locally
- [ ] Staging
