### PR TITLE
Fix Appraisals version constraints for Rails 6.0

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -21,16 +21,16 @@ appraise "rails-5.2_pg-1.2" do
 end
 
 appraise "rails-6.0_pg-0.18" do
-  gem "activerecord", ">= 6.0.0", "<= 6.1"
+  gem "activerecord", ">= 6.0.0", "< 6.1"
   gem "pg", "0.18.4"
 end
 
 appraise "rails-6.0_pg-1.1" do
-  gem "activerecord", ">= 6.0.0", "<= 6.1"
+  gem "activerecord", ">= 6.0.0", "< 6.1"
   gem "pg", "1.1.4"
 end
 
 appraise "rails-6.0_pg-1.2" do
-  gem "activerecord", ">= 6.0.0", "<= 6.1"
+  gem "activerecord", ">= 6.0.0", "< 6.1"
   gem "pg", "1.2.0"
 end


### PR DESCRIPTION
## What did we change?
Change `<= 6.1` version constraint to `< 6.1`

## Why are we doing this?
Now that Rails 6.1 has been released this will cause any builds to fail
because bundler will choose the latest activerecord version (6.1) which
violates the gempspec version constraints and causes gem load failures

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
