### PR TITLE
Fix pg gem version constraint

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,14 +50,6 @@ jobs:
 
       # Run tests for each appraisal
       - run:
-          name: rails-5.1
-          command: bundle exec appraisal rails-5.1 rspec --format RspecJunitFormatter --format progress
-
-      - run:
-          name: rails-5.2_pg-0.18
-          command: bundle exec appraisal rails-5.2_pg-0.18 rspec --format RspecJunitFormatter --format progress
-
-      - run:
           name: rails-5.2_pg-1.1
           command: |
             bundle exec appraisal rails-5.2_pg-1.1 rspec --format RspecJunitFormatter --format progress
@@ -66,11 +58,6 @@ jobs:
           name: rails-5.2_pg-1.2
           command: |
             bundle exec appraisal rails-5.2_pg-1.2 rspec --format RspecJunitFormatter --format progress
-
-      - run:
-          name: rails-6.0_pg-0.18
-          command: |
-            bundle exec appraisal rails-6.0_pg-0.18 rspec --format RspecJunitFormatter --format progress
 
       - run:
           name: rails-6.0_pg-1.1

--- a/Appraisals
+++ b/Appraisals
@@ -1,28 +1,13 @@
 # frozen_string_literal: true
 
-appraise "rails-5.1" do
-  gem "activerecord", "5.1.6"
-  gem "pg", "0.18.4"
-end
-
 appraise "rails-5.2_pg-1.1" do
   gem "activerecord", "5.2.1"
   gem "pg", "1.1.4"
 end
 
-appraise "rails-5.2_pg-0.18" do
-  gem "activerecord", "5.2.1"
-  gem "pg", "0.18.4"
-end
-
 appraise "rails-5.2_pg-1.2" do
   gem "activerecord", "5.2.1"
   gem "pg", "1.2.0"
-end
-
-appraise "rails-6.0_pg-0.18" do
-  gem "activerecord", ">= 6.0.0", "< 6.1"
-  gem "pg", "0.18.4"
 end
 
 appraise "rails-6.0_pg-1.1" do

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # activerecord-postgres_pub_sub
 
+## v2.0.1 (unreleased)
+- Fix version constraint on pg gem.
+- Drop support for rails 5.1 as a result of pg constraint change.
+
 ## v2.0.0
 - Add support for Rails 6.1.
 - Drop support for pg 0.18 as support has been [dropped in activerecord 6.1](https://github.com/rails/rails/commit/592358e182effecebe8c6a4645bd4431f5a73654).

--- a/activerecord-postgres_pub_sub.gemspec
+++ b/activerecord-postgres_pub_sub.gemspec
@@ -40,8 +40,8 @@ Gem::Specification.new do |spec|
   spec.executables   = []
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "activerecord", ">= 5.1", "< 6.2"
-  spec.add_runtime_dependency "pg", ">= 0.18", "< 2.0"
+  spec.add_runtime_dependency "activerecord", "> 5.1", "< 6.2"
+  spec.add_runtime_dependency "pg", "~> 1.1"
   spec.add_runtime_dependency "private_attr"
   spec.add_runtime_dependency "with_advisory_lock"
 

--- a/lib/activerecord/postgres_pub_sub/version.rb
+++ b/lib/activerecord/postgres_pub_sub/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module PostgresPubSub
-    VERSION = "2.0.0"
+    VERSION = "2.0.1"
   end
 end


### PR DESCRIPTION
## What did we change?
change `pg` version constraint to `~> 1.1` and drop support for rails 5.1

## Why are we doing this?
When i extended support to rails 6.1 i totally forgot to narrow the version constraint for the `pg` gem :facepalm: :facepalm: 
also drop support for rails 5.1 as it won't support pg 1.0 and greater.

## How was it tested?
- [ ] Specs
- [x] Locally
- [ ] Staging
