### PR TITLE
dep: support rails 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        activerecord: [ '5.2', '6.0', '6.1', '7.0' ]
+        activerecord: [ '5.2', '6.0', '6.1', '7.0', '7.1' ]
         pg: [ '1.1', '1.2' ]  # FU: Build against common pg 1.x minor versions
         ruby: [ '2.7' ]  # FU: Build against common ruby 3.x minor versions
     timeout-minutes: 10

--- a/Appraisals
+++ b/Appraisals
@@ -39,3 +39,13 @@ appraise "rails-7.0_pg-1.2" do
   gem "activerecord", ">= 7.0.0", "< 7.1"
   gem "pg", "1.2.0"
 end
+
+appraise "rails-7.1_pg-1.1" do
+  gem "activerecord", ">= 7.1.0", "< 7.2"
+  gem "pg", "1.1.4"
+end
+
+appraise "rails-7.1_pg-1.2" do
+  gem "activerecord", ">= 7.1.0", "< 7.2"
+  gem "pg", "1.2.0"
+end

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # activerecord-postgres_pub_sub
 
+## v2.3.0
+- Add support for Rails 7.1
+
 ## v2.2.0
 - Add support for listening to multiple channels.
 

--- a/activerecord-postgres_pub_sub.gemspec
+++ b/activerecord-postgres_pub_sub.gemspec
@@ -41,7 +41,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.7.0"
 
-  spec.add_runtime_dependency "activerecord", "> 5.1", "< 7.1"
+  spec.add_runtime_dependency "activerecord", "> 5.1", "< 7.2"
   spec.add_runtime_dependency "pg", "~> 1.1"
   spec.add_runtime_dependency "private_attr"
   spec.add_runtime_dependency "with_advisory_lock"

--- a/lib/activerecord/postgres_pub_sub/version.rb
+++ b/lib/activerecord/postgres_pub_sub/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module PostgresPubSub
-    VERSION = "2.2.0"
+    VERSION = "2.3.0"
   end
 end


### PR DESCRIPTION
## What did we change?

Test against `active_record ~> 7.1` & allow it in our dependencies.

## Why are we doing this?

Resolves #26

## How was it tested?
- [x] Specs
- [ ] Locally
- [ ] Staging
