### PR TITLE
add multiple database support by allowing injection of a different AR base class

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # activerecord-postgres_pub_sub
 
 ## Unreleased
+- Add support for multiple databases by allowing injection of the base Active Record class.
 - BREAKING: Drop support for ActiveRecord 5.2, 6.0
 - BREAKING: Drop support for ruby < 3.0
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,8 @@ When creating a listener, the following configuration is supported:
   the listener ignores the payload and coalesces multiple notifications into a
   single call. When this option is `false`, the `on_notify` block is called with
   the payload for each notification. (Default `true`).
+* **base_class**: An Active Record class should you need to use a different base
+  class (e.g. for multiple database support). (Default `ActiveRecord::Base`).
 * **exclusive_lock**: Acquire a lock using
   [with_advisory_lock](https://github.com/ClosureTree/with_advisory_lock) prior to listening.
   This option ensures that a process as a singleton listener. (Default `true`).

--- a/lib/activerecord/postgres_pub_sub/listener.rb
+++ b/lib/activerecord/postgres_pub_sub/listener.rb
@@ -9,22 +9,36 @@ module ActiveRecord
       extend PrivateAttr
 
       private_attr_reader :on_notify_blk, :on_start_blk, :on_timeout_blk,
-                          :channels, :listen_timeout, :exclusive_lock, :notify_only
+                          :channels, :listen_timeout, :exclusive_lock, :notify_only, :base_class
 
-      def self.listen(*channels, listen_timeout: nil, exclusive_lock: true, notify_only: true)
+      def self.listen(
+        *channels,
+        listen_timeout: nil,
+        exclusive_lock: true,
+        notify_only: true,
+        base_class: ActiveRecord::Base
+      )
         listener = new(*channels,
                        listen_timeout: listen_timeout,
                        exclusive_lock: exclusive_lock,
-                       notify_only: notify_only)
+                       notify_only: notify_only,
+                       base_class: base_class)
         yield(listener) if block_given?
         listener.listen
       end
 
-      def initialize(*channels, listen_timeout: nil, exclusive_lock: true, notify_only: true)
+      def initialize(
+        *channels,
+        listen_timeout: nil,
+        exclusive_lock: true,
+        notify_only: true,
+        base_class: ActiveRecord::Base
+      )
         @channels = channels
         @listen_timeout = listen_timeout
         @exclusive_lock = exclusive_lock
         @notify_only = notify_only
+        @base_class = base_class
       end
 
       def on_notify(&blk)
@@ -54,7 +68,7 @@ module ActiveRecord
       private
 
       def with_connection
-        ActiveRecord::Base.connection_pool.with_connection do |connection|
+        base_class.connection_pool.with_connection do |connection|
           with_optional_lock do
             channels.each do |channel|
               connection.execute("LISTEN #{channel};")
@@ -73,7 +87,7 @@ module ActiveRecord
 
       def with_optional_lock(&block)
         if exclusive_lock
-          ActiveRecord::Base.with_advisory_lock(lock_name, &block)
+          base_class.with_advisory_lock(lock_name, &block)
         else
           yield
         end


### PR DESCRIPTION
## What did we change?

Now, you can inject which base class you want to use when setting up the listener. It still defaults to `ActiveRecord::Base`.

## Why are we doing this?

Multiple databases can be easily supported in recent versions of Rails / Active Record, and one way to do that is to have a different abstract Active Record base class with different connection configuration via [`connected_to`](https://api.rubyonrails.org/classes/ActiveRecord/ConnectionHandling.html#method-i-connected_to).

Closes #22.

## How was it tested?
- [x] Specs
- [x] Locally
- [ ] Staging
