### PR TITLE
release: v3.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # activerecord-postgres_pub_sub
 
-## Unreleased
+## v3.0.0
 - Add support for multiple databases by allowing injection of the base Active Record class.
 - BREAKING: Drop support for ActiveRecord 5.2, 6.0
 - BREAKING: Drop support for ruby < 3.0

--- a/lib/activerecord/postgres_pub_sub/version.rb
+++ b/lib/activerecord/postgres_pub_sub/version.rb
@@ -2,6 +2,6 @@
 
 module ActiveRecord
   module PostgresPubSub
-    VERSION = "2.3.0"
+    VERSION = "3.0.0"
   end
 end


### PR DESCRIPTION
## What did we change?

Cut a new release, including these changes:

- Add support for multiple databases by allowing injection of the base Active Record class.
- BREAKING: Drop support for ActiveRecord 5.2, 6.0
- BREAKING: Drop support for ruby < 3.0

## Why are we doing this?

We now have a new functional change, so we're releasing a new version to make that feature available.

BREAKING: This release drops support for Active Record and Ruby versions which are EOL.