### PR TITLE
[DEVEX-3429] Authenticate Docker Pulls in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,6 +54,9 @@ jobs:
     services:
       postgres:
         image: postgres:16.1
+        credentials:
+          username: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_CONTAINER_REGISTRY_PASSWORD }}
         env:
           POSTGRES_USER: postgres
           POSTGRES_DB: postgres_pub_sub_test


### PR DESCRIPTION
## What did we change?

Added DockerHub credentials when pulling images during CI.

## Why are we doing this?

[DEVEX-3429](https://ezcater.atlassian.net/browse/DEVEX-3429)

We're accidentally DOS-ing ourselves from pulling Docker images during CI runs. Every pull that isn't authenticated puts us one step closer to hitting Docker's [Abuse rate limit](https://docs.docker.com/docker-hub/usage/#abuse-rate-limit). We have been hitting this on a semi-regular basis lately, which requires developers to babysit CI through multiple attempts until either we fall far enough below the abuse threshold or jobs get assigned to an alternate runner IP that has not yet hit its limit.


[DEVEX-3429]: https://ezcater.atlassian.net/browse/DEVEX-3429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ