### PR TITLE
fix: add deprecation warnings for gem archival

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 # activerecord-postgres_pub_sub
 
+> [!WARNING]
+> This gem has been archived by ezCater and will no longer be receiving updates.
+
 This gem contains support for PostgreSQL LISTEN and NOTIFY functionality:
 [doc](https://www.postgresql.org/docs/9.6/static/libpq-notify.html).
 

--- a/activerecord-postgres_pub_sub.gemspec
+++ b/activerecord-postgres_pub_sub.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/ezcater/activerecord-postgres_pub_sub"
   spec.license       = "MIT"
+  spec.post_install_message = "WARNING: activerecord-postgres_pub_sub has been archived by ezCater and is no longer maintained. This gem will not receive further updates."
 
   # Set "allowed_push_post" to control where this gem can be published.
   if spec.respond_to?(:metadata)

--- a/activerecord-postgres_pub_sub.gemspec
+++ b/activerecord-postgres_pub_sub.gemspec
@@ -13,7 +13,8 @@ Gem::Specification.new do |spec|
   spec.description   = spec.summary
   spec.homepage      = "https://github.com/ezcater/activerecord-postgres_pub_sub"
   spec.license       = "MIT"
-  spec.post_install_message = "WARNING: activerecord-postgres_pub_sub has been archived by ezCater and is no longer maintained. This gem will not receive further updates."
+  spec.post_install_message = "WARNING: activerecord-postgres_pub_sub has been archived by ezCater and is no longer " \
+                              "maintained. This gem will not receive further updates."
 
   # Set "allowed_push_post" to control where this gem can be published.
   if spec.respond_to?(:metadata)

--- a/lib/activerecord-postgres_pub_sub.rb
+++ b/lib/activerecord-postgres_pub_sub.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+warn "WARNING: activerecord-postgres_pub_sub has been archived by ezCater and is no longer maintained. " \
+     "This gem will not receive further updates."
+
 require "active_record"
 require "activerecord/postgres_pub_sub/version"
 require "activerecord/postgres_pub_sub/listener"


### PR DESCRIPTION
## Summary
- Adds a `> [!WARNING]` callout to the README indicating the gem is archived
- Adds a `post_install_message` to the gemspec shown at `bundle install`
- Adds a `warn` to stderr on every `require` of the gem

## Test plan
- [x] Verify CI passes
- [ ] After merge, manually dispatch the `Release Gem` workflow to publish `3.4.1` to RubyGems
- [ ] Archive the repo on GitHub once the private `activerecord-pg_pub_sub` gem is ready and consumers are migrated ([MX-1375](https://ezcater.atlassian.net/browse/MX-1375))

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[MX-1375]: https://ezcater.atlassian.net/browse/MX-1375?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ